### PR TITLE
html5Preloader initiation without new keyword

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -291,6 +291,9 @@ loadFile.document = function (file, callback) {
 }());
 
 function html5Preloader () {
+	if (!(this instanceof html5Preloader)) {
+		return arguments.length ? (new html5Preloader(arguments[0])) : (new html5Preloader());
+	}
 	var self = this;
 
 	self.files = [];


### PR DESCRIPTION
Will allow html5Preloader to be used in the function syntax, rather than that object syntax. Some people prefer to do it this way, or some people just don't know about the object syntax.

``` javascript
// Function syntax
var loader = html5Preloader(...); // Will be made possible by this commit

// Object syntax
var loader = new html5Preloader(...); // Old way
```
