### PR TITLE
Loading binaries via xhr in ie8, adding 'timeout' support

### DIFF
--- a/js/html5Preloader.js
+++ b/js/html5Preloader.js
@@ -366,10 +366,15 @@ html5Preloader.prototype = {
 	files: null,
 	filesLoading: 0,
 	filesLoaded: 0,
+	filesLoadedMap: {},
 	timeout: null,
 
 	loadCallback: function (e, f) {
-		this.filesLoaded++;
+
+		if (!this.filesLoadedMap[f.id]) {
+			this.filesLoaded++;
+			this.filesLoadedMap[f.id] = f;
+		}
 
 		this.emit(e ? 'error' : 'fileloaded', e ? [e, f] : [f]);
 

--- a/js/html5Preloader.js
+++ b/js/html5Preloader.js
@@ -270,13 +270,17 @@ loadFile.document = function (file, callback) {
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState !== 4) return;
 
-		var dom = self.dom = xhr.responseXML && xhr.responseXML.documentElement ?
-			xhr.responseXML :
-			String(xhr.responseText || '') ;
+		try {
+			self.dom = xhr.responseXML && xhr.responseXML.documentElement ?
+				xhr.responseXML :
+				String(xhr.responseText || '') ;
 
-		xhr.status === 200 ?
-			callback(null, self) :
-			callback({e: Error('Request failed: ' + xhr.status)}, self) ;
+			xhr.status === 200 ?
+				callback(null, self) :
+				callback({e: Error('Request failed: ' + xhr.status)}, self) ;
+		} catch (e) {
+			callback({e: e}, self);
+		}
 	};
 
 	xhr.onerror = function (e) {


### PR DESCRIPTION
2 extra features:
- fixed issue that arose when attempting to preload a binary file via xhr in IE8
- added a `timeout` property on html5Preloader objects. if set, will cause an 'error' event for any file that takes longer than `timeout`ms to load.

Just noticed a new branch on your project -- if that's still going on, will happily re-submit there as well.
